### PR TITLE
Add travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+# Select a main language
+language: c
+
+# Select the operating system (either linux or osx)
+os:
+  - linux
+
+# Run some pre-install commands, here install fftw and gsl
+before_install:
+  - sudo apt-get -qq update
+  - sudo apt-get install -y libfftw3-dev libgsl0-dev
+
+# Main building and install step
+install:
+  - make
+
+# Runs tests and do extra stuff
+script:
+  - ./verif.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
 
 # Main building and install step
 install:
-  - make
+  - make angpow
 
 # Runs tests and do extra stuff
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
 
 # Main building and install step
 install:
-  - make angpow
+  - make all
 
 # Runs tests and do extra stuff
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ install:
 
 # Runs tests and do extra stuff
 script:
-  - ./verif.sh
+  - bash verif.sh

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Angular Power spectrum
+Angular Power spectrum [![Build Status](https://travis-ci.org/EiffL/Angpow4CCL.svg?branch=master)](https://travis-ci.org/EiffL/Angpow4CCL)
 ======================================
 Version 2.x (last update of this file 5-Jan-17)
 
@@ -10,34 +10,34 @@ The authors thank M. Reinecke for fruitful discussions and some tools he give us
 
 
 # Introduction
-**Angpow** performs the computation of the angular spectrum $C_\ell(z_1,z_2)$ between two shells of redshifts $z_1$, $z_2$   according to the following definition 
+**Angpow** performs the computation of the angular spectrum $C_\ell(z_1,z_2)$ between two shells of redshifts $z_1$, $z_2$   according to the following definition
 $$\begin{equation}
 C_{\ell}(z_1, z_2) = \frac{2}{\pi} \int dk\ k^2\ P(k) \Delta_{\ell}(z_1, k)\Delta_{\ell}(z_2, k)
 \label{eq-cl-def}
 \end{equation}$$
-with in one hand $P(k)$ the non normalized primordial power spectrum and 
+with in one hand $P(k)$ the non normalized primordial power spectrum and
 $$\begin{equation}
 \Delta_{\ell}(z, k) \approx  j_{\ell}(k\,r(z))\  \tilde{\Delta}_{\ell}(z, k)
 \label{eq-DeltaFunc-def}
 \end{equation}$$
-where $j_\ell(x)$ is a first kind spherical Bessel function of parameter $\ell$, $r(z)$ the radial comoving distance of perturbations and $\tilde{\Delta}_{\ell}(z, k)$ a generic function that at least takes into account of the growth factor between $z=0$ and a diffrent $z$ value. When one introduces redshift selection functions arround $z_1$ and $z_2$, **Angpow** computes 
+where $j_\ell(x)$ is a first kind spherical Bessel function of parameter $\ell$, $r(z)$ the radial comoving distance of perturbations and $\tilde{\Delta}_{\ell}(z, k)$ a generic function that at least takes into account of the growth factor between $z=0$ and a diffrent $z$ value. When one introduces redshift selection functions arround $z_1$ and $z_2$, **Angpow** computes
 $$\begin{equation}
 \begin{split}
-C_{\ell}(z_1, z_2) &=  \frac{2}{\pi} \iint dz\ dz^\prime \ W_1(z; z_1, \sigma_1) W_2(z^\prime; z_2, \sigma_2) 
-\\ & \times \int dk\ k^2\ P(k)  \Delta_{\ell}(z, k)\Delta_{\ell}(z^\prime, k) 
+C_{\ell}(z_1, z_2) &=  \frac{2}{\pi} \iint dz\ dz^\prime \ W_1(z; z_1, \sigma_1) W_2(z^\prime; z_2, \sigma_2)
+\\ & \times \int dk\ k^2\ P(k)  \Delta_{\ell}(z, k)\Delta_{\ell}(z^\prime, k)
  \label{eq-clz1z2-obs}
 \end{split}
 \end{equation}$$
 
-The method used is a mixture of cartesian quadrature in the redshift 2D-space and a Clenshaw-Curtis-Chebyshev algorithm to perform the integral along the $k$ direction. 
+The method used is a mixture of cartesian quadrature in the redshift 2D-space and a Clenshaw-Curtis-Chebyshev algorithm to perform the integral along the $k$ direction.
 
-It is also provided once the $C_\ell$ are computed, an evaluation of the truncated regularized angular correlation function $\xi(\theta, z_1, z_2)$ 
+It is also provided once the $C_\ell$ are computed, an evaluation of the truncated regularized angular correlation function $\xi(\theta, z_1, z_2)$
 $$\begin{equation}
- \xi(\theta, z_1, z_2) = \frac{1}{4\pi}\sum^{L_{max}}_{\ell=0} (2 \ell+1)C_\ell(z_1,z_2) P_\ell(\cos\theta)e^{-\ell(\ell+1)/\ell_s^2} 
+ \xi(\theta, z_1, z_2) = \frac{1}{4\pi}\sum^{L_{max}}_{\ell=0} (2 \ell+1)C_\ell(z_1,z_2) P_\ell(\cos\theta)e^{-\ell(\ell+1)/\ell_s^2}
 \end{equation}$$
 The apodization function depends on the $\ell_s$ scale which depends on $L_{max}$, i.e. one may take as a rule of thumb $\ell_s \approx 0.4 L_{max}$. Notice that $1/\ell_s$ gives an achieivable resolution (in radian) due to the apodization.
 
-	
+
 # Download		
 Download as Guest
 git clone git@gitlab.in2p3.fr:campagne/AngPow.git
@@ -53,17 +53,17 @@ The library is avaliable [here](http://www.fftw.org/download.html). Use `./confi
 # Compilation/Installation/Setup
 
 1. edit Makefile and adapat to local platform :
-	
-	* adapt to the type of Machine MacOSX (Darwin) vs Linux 
+
+	* adapt to the type of Machine MacOSX (Darwin) vs Linux
  	* on Linux adapt the location of FFTW
- 			 
+
 2. Then, the make depends on the plateform
- 
-		> make 
+
+		> make
 
 	will select the system thanks tu uname shell function. The result of "make" is binanry file under `./bin` directory as well as `libanpow.a` library in `./lib`.
-  
-3. if you want a detailed profiling report then, 
+
+3. if you want a detailed profiling report then,
 
    		> make PROFILING=1
 
@@ -71,15 +71,15 @@ The library is avaliable [here](http://www.fftw.org/download.html). Use `./confi
 
 Other possible argument to make:
 - make clean: to cleanup objects, angpow library and binary
-- make tidy:  to delete all ~ files 
+- make tidy:  to delete all ~ files
 - make fullcheck: to run in different initial conditions (see below).
 
 
 
 # Plateform tested
 	Mac OS X 10.11.2:  gcc 4.9
-	Linuxx86_64: gcc 4.9 and 5.2 + intel icpc 15.01 
-	
+	Linuxx86_64: gcc 4.9 and 5.2 + intel icpc 15.01
+
 	Has been tested on Laptop, on CCIN2P3 and NERSC computers.
 
 # Running
@@ -87,9 +87,9 @@ As **Angpow** uses OpenMP when necessary, the user is invited to set the number 
 
 	> export OMP_NUM_THREADS=<number>
 	> ./bin/angpow anpow_bench<>.ini
-	
-All the following input parameters uses a $P(k)$ at $z=0$ produced by CLASSgal with matter density fluctuation only and a standard Cosmology. The details of the 5 input parameter examples are currently: 
- 	
+
+All the following input parameters uses a $P(k)$ at $z=0$ produced by CLASSgal with matter density fluctuation only and a standard Cosmology. The details of the 5 input parameter examples are currently:
+
 * 	anpow\_bench1.ini: Auto correlation, Dirac selection at $z = 1$
 *  angpow\_bench2.ini:  Cross correlation, Dirac selection $z = 1, 1.05$
 *  angpow\_bench3.ini: Auto correlation, Gauss & Galaxy example (cf. $dN/dz$) selection (to repproduce an example in the CLASSgal article [arXiv:1307.1459v4](https://arxiv.org/pdf/1307.1459v4.pdf)  $\langle z \rangle = 0.55$, $\sigma_z=0.10$.
@@ -109,7 +109,7 @@ It is provided a bash script `stress-test.sh` that runs the 5 Tests with diffren
 	* Darwin\_g++\_omp\_make.inc : file included into Makefile in case of running on Mac Os X system
 	* Linux\_g++\_make.inc : idem but for Linux system
 	* angpow.cc: it contains the main() function to perform a generic $C_\ell$ computaion using initial parameter files
-	* angpow\_bench\<*number*\>.ini a set of initial parameter files which show how to proceed to run the job: 
+	* angpow\_bench\<*number*\>.ini a set of initial parameter files which show how to proceed to run the job:
 
 	`./bin/angpow <init-file>`
 
@@ -123,7 +123,7 @@ It is provided a bash script `stress-test.sh` that runs the 5 Tests with diffren
 	* angpow\_exceptions: exception class
 	* angpow\_fft: access to FFTW planning
 	* angpow\_func: base class for generic 1D and 2D functions
-	* angpow\_kinteg: perform the k-integration (bulk of the algo) and the redshift integrations too 
+	* angpow\_kinteg: perform the k-integration (bulk of the algo) and the redshift integrations too
 	* angpow\_numbers: to generate machine-based number types (M. Reinecke)
 	* angpow\_parameters: structure which group the user parameters to control the job at diffrent stages (directory, precision, cuts...)
 	* angpow\_pk2cl: hub of the program to perfom the $C_\ell$ computation  from a $P(k)$ and redshift selection windows
@@ -132,40 +132,40 @@ It is provided a bash script `stress-test.sh` that runs the 5 Tests with diffren
 	* angpow\_quadinteg: generic and specific 1D quadrature. Used to get low order weights/nodes for instance of Clenshaw-Curtis or Gauss-Kronrod quadrature. This is used for the redshift integrals of the $C_\ell$ with selection functions.
 	* angpow\_radial\_base.h: base class for redshift selection function
 	* angpow\_radial: implement angpow\_radial\_base.h: Dirac, TopHat with apodized edges, Gaussian, and Gauss + Galaxy distribution
-	* angpow\_radint: originaly was design to perform the redshift integral but it is only used to provide cartesian quadrature weights/nodes as angpow\_kinteg perform all the integrals. It might be cleaned in future relased. 
+	* angpow\_radint: originaly was design to perform the redshift integral but it is only used to provide cartesian quadrature weights/nodes as angpow\_kinteg perform all the integrals. It might be cleaned in future relased.
 	* angpow\_tools: spline, interpolation...
 	* angpow\_utils: string manipulation and STL predicates
 	* walltime\_c/walltimer: M. Reinecke usefull timer.
-* **root** directory 
+* **root** directory
 	* Makefile that should be tuned to the local platform (*.inc files)
 	* the main (angpow.cc or limber.cc)
 	* initial parameter files (angpow_bench\<*number*\>.ini)
 	* reference outputs (angpow_bench\<*number*\>.txt.REF)
 	* bash scripts (verif.sh, stress-test.sh) and an awk script (diff.awk) used by verif.sh.
-* **doc** directory 
-	* doxydoc : input file to `doxygen` tool to generate the class documentation 
-* **bin**/**lib** directories are the location of executable and library 
+* **doc** directory
+	* doxydoc : input file to `doxygen` tool to generate the class documentation
+* **bin**/**lib** directories are the location of executable and library
 * **data** directory:
 	* input power
 
 # Abstract class implementation
 **Angpow** design has been driven to allow one to use its own access to :
- 
+
 * power spectrum computation (ie. $P(k)$, $\tilde{\Delta}_\ell(z,k)$. These functions are generalised in a single $P(\ell, k, z)$ function which has to be derived from  `PowerSpecBase` class located in `angpow_power_spec_base.h` file. An concrete implementation has been set up in `angpow_power.h` throw the `PowerSpecFile`class which reads an external $(k, P(k))$ tuple and compute internaly a minimal growth function. To implement `PowerSpecBase` one **must** provide:
 	* a `clone` function that is simply (Derived to be replaced by the appropriate class name)
-				
+
 			return new Derived(static_cast<const Derived&>(*this));		
 The Copy Constructor should be explicitly provided BUT avoid deep copy if pointers are used (see for instance `PowerSpecFile`),
 	* the main operator `double operator()(int ell, double k, double z)`.
 	* if pointers are used than one must provide an implementation of `ExplicitDestroy()` to free properly the memory. `Do not use the Destructor of the class to free memory that is used by different clone`.
-	* Before the $k$-sampling at fixed $\ell$ and $z_i$ values the `Init` function is called by the KIntegrator::compute method, so the user can initialize function at this stage (for instance any growth factor depending only on $z$). 
+	* Before the $k$-sampling at fixed $\ell$ and $z_i$ values the `Init` function is called by the KIntegrator::compute method, so the user can initialize function at this stage (for instance any growth factor depending only on $z$).
 * cosmological comobile distance (ie. $r(z)$) those abstract class `CosmoCoordBase` is located in `angpow_cosmo_base.h` file. An implementation using a $\Lambda$CDM standard cosmology is accessible throw `CosmoCoord` class in `angpow_cosmo.h`
 * radial selection functions (ie. $W(z)$) as a $z$ user function derived from `RadSelectBase` class in `angpow_radial_base.h` file. Some implementations exist for Dirac, Gaussian, TopHat with apodized edges, and Gaussian+galaxy function (see details in `angpow_radial.h` file)  
 
 The user once he has implemented the abstract classes, may want to set up an application similar to `angpow.cc`. In this perspective the typical workflow of the main routine should at least follow the scheme:
 
 1. Get the pointer to the job processing user parameters via
-       
+
         Parameters para = Param::Instance().GetParam();
 2. Initialize the Redshift Selection classes derived from `RadSelectBase`;
 3. Initialize the Cosmological Distance class derived from  `CosmoCoordBase`;
@@ -181,5 +181,3 @@ The user once he has implemented the abstract classes, may want to set up an app
 8. Before closing (free memory if needed) one must explicitly call the PowerSpectrum `ExplicitDestroy` method.
 
 		pws.ExplicitDestroy();		
-
- 


### PR DESCRIPTION
This pull request adds a simple travis CI script to angpow4ccl. The script itself should be straightforward.

To enable travis on this repository, first create a travis CI account on https://travis-ci.org/ and accept the connection to your github account. Once signed in on travis, there should be a button like this for angpow4ccl, just switch it and the build should start (maybe on the next commit)
![](https://docs.travis-ci.com/images/enable.png)

Checkout this page for a quick intro to travis: https://docs.travis-ci.com/user/getting-started/

And slack me with any questions :-)