### PR TITLE
update to adapt latest ccl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ project(angpow)
       set(CMAKE_CXX_FLAGS "-Wall -Wpointer-arith -O3 -fPIC -std=c++11 -fopenmp  -fno-common  -Wall -march=native -ffast-math -m64")
     endif()
 
+    SET(CMAKE_CXX_FLAGS_DEBUG "-O0 -g")
 
     # Defines list of Angpow library src files
     set(ANGPOW_SRC src/walltimer.cc src/walltime_c.cc src/angpow_bessel.cc

--- a/inc/Angpow/angpow_ccl.h
+++ b/inc/Angpow/angpow_ccl.h
@@ -1,54 +1,137 @@
 #ifndef ANGPOW_CCL_SEEN
 #define ANGPOW_CCL_SEEN
 
-#include "ccl_cls.h"
-#include "ccl_power.h"
-#include "ccl_background.h"
-#include "ccl_error.h"
-#include "ccl_utils.h"
+#include "ccl.h"
+
+#include <math.h>
+
 #include "Angpow/angpow_ccl_private.h"
 
 //#pragma once
 
 #ifdef HAVE_ANGPOW
 
-//this is the public Angpow interface function to be used within CCL
-void ccl_angular_cls_angpow(ccl_cosmology *ccl_cosmo,CCL_ClWorkspace *w,
-				   CCL_ClTracer *clt1,CCL_ClTracer *clt2,
-				   double *cl_out,int * status)
+ccl_f1d_t *new_redshift_kernel(ccl_f1d_t *kernel, ccl_cosmology *cosmo, int *status)
 {
+  if (kernel == NULL)
+    return NULL;
 
-  struct angpow_cltracer a_clt1;
-  struct angpow_cltracer a_clt2;
-  struct angpow_clworkspace a_w;
-  a_clt1.has_rsd = clt1->has_rsd;  a_clt1.has_magnification = clt1->has_magnification;
-  a_clt1.chimin = clt1->chimin;    a_clt1.chimax = clt1->chimax;
-  a_clt1.zmin = clt1->zmin;        a_clt1.zmax = clt1->zmax;
-  a_clt1.spl_bz = clt1->spl_bz;    a_clt1.spl_nz = clt1->spl_nz;
+  ccl_f1d_t *kn_z = NULL;
+  size_t n = kernel->spline->size;
+  double *z, *wz;
 
-  a_clt2.has_rsd = clt2->has_rsd;  a_clt2.has_magnification = clt2->has_magnification;
-  a_clt2.chimin = clt2->chimin;    a_clt2.chimax = clt2->chimax;
-  a_clt2.zmin = clt2->zmin;        a_clt2.zmax = clt2->zmax;
-  a_clt2.spl_bz = clt2->spl_bz;    a_clt2.spl_nz = clt2->spl_nz;
-  
-  a_w.lmax=w->lmax; a_w.l_limber=w->l_limber; a_w.l_linstep = w->l_linstep;
-  a_w.l_logstep = w->l_logstep; a_w.l_arr = w->l_arr;
-  
-  ccl_angular_cls_angpow_default(ccl_spline_eval, ccl_comoving_radial_distance,
-				 ccl_scale_factor_of_chi, ccl_growth_rate,
-				 ccl_nonlin_matter_power,
-				 ccl_cosmo, w, clt1, clt2,
-				 &a_clt1, &a_clt2, &a_w,    
-				 ccl_cosmo->status_message, cl_out, status);
+  z = malloc(sizeof(double) * n);
+  if (z == NULL)
+    *status = CCL_ERROR_MEMORY;
+  wz = malloc(sizeof(double) * n);
+  if (wz == NULL)
+    *status = CCL_ERROR_MEMORY;
 
+  if (*status == 0)
+  {
+    for (int iz = 0; iz < n; iz++)
+    {
+      double a = ccl_scale_factor_of_chi(cosmo, kernel->spline->x[iz], status);
+      double hz = cosmo->params.h * ccl_h_over_h0(cosmo, a, status) / ccl_constants.CLIGHT_HMPC;
+
+      z[iz] = 1. / a - 1.;
+      wz[iz] = kernel->spline->y[iz] / hz; // W(z) = W(chi) * dchi/dz = W(chi)/H(z)
+    }
+    kn_z = ccl_f1d_t_new(n, z, wz, kernel->y0, kernel->yf, kernel->extrap_lo_type, kernel->extrap_hi_type, status);
+  }
+
+  if (z != NULL)
+    free(z);
+  if (wz != NULL)
+    free(wz);
+
+  return kn_z;
+}
+
+ccl_cl_tracer_t *new_redshift_tracer(ccl_cl_tracer_t *tracer, ccl_cosmology *cosmo, int *status)
+{
+  ccl_cl_tracer_t *tr_z = malloc(sizeof(ccl_cl_tracer_t));
+  if (tr_z == NULL)
+    *status = CCL_ERROR_MEMORY;
+
+  if (*status == 0)
+  {
+    tr_z->der_angles = tracer->der_angles;
+    tr_z->der_bessel = tracer->der_bessel;
+    tr_z->transfer = tracer->transfer;
+    tr_z->chi_min = 1. / ccl_scale_factor_of_chi(cosmo, tracer->chi_min, status) - 1.;
+    tr_z->chi_max = 1. / ccl_scale_factor_of_chi(cosmo, tracer->chi_max, status) - 1.;
+    tr_z->kernel = NULL;
+    if (tracer->kernel != NULL)
+    {
+      tr_z->kernel = new_redshift_kernel(tracer->kernel, cosmo, status);
+    }
+  }
+
+  if (*status)
+  {
+    ccl_cl_tracer_t_free(tr_z);
+    tr_z = NULL;
+  }
+  return tr_z;
+}
+
+double redshift_tracer_get_kernel(ccl_cl_tracer_t *tr, double z, int *status) {
+  if (tr != NULL && tr->kernel != NULL)
+    return ccl_f1d_t_eval(tr->kernel, z);
+  else
+    return 1.0;
+}
+
+void set_tracer_range(struct tracer_range *range, ccl_cl_tracer_t *tr_chi, ccl_cl_tracer_t *tr_z)
+{
+  range->chimin = tr_chi->chi_min;
+  range->chimax = tr_chi->chi_max;
+  range->zmin = tr_z->chi_min;
+  range->zmax = tr_z->chi_max;
+}
+
+// this is the public Angpow interface function to be used within CCL
+void ccl_angular_cls_angpow(ccl_cosmology *ccl_cosmo,
+				   ccl_cl_tracer_t *clt1, ccl_cl_tracer_t *clt2, ccl_f2d_t *psp,
+				   int nl_out, int *l_out, double *cl_out, int *status)
+{
+  struct tracer_range clt1_range, clt2_range;
+  ccl_cl_tracer_t *clt1_z, *clt2_z;
+
+  clt1_z = new_redshift_tracer(clt1, ccl_cosmo, status);
+  clt2_z = new_redshift_tracer(clt2, ccl_cosmo, status);
+  if (*status == 0)
+  {
+    set_tracer_range(&clt1_range, clt1, clt1_z);
+    set_tracer_range(&clt2_range, clt2, clt2_z);
+
+    ccl_angular_cls_angpow_default(
+        ccl_f1d_t_eval, ccl_f2d_t_eval,
+        ccl_comoving_radial_distance, ccl_scale_factor_of_chi,
+        redshift_tracer_get_kernel, ccl_cl_tracer_t_get_transfer,
+        psp, ccl_cosmo, clt1_z, clt2_z, &clt1_range, &clt2_range, l_out, nl_out,
+        ccl_cosmo->status_message, cl_out, status);
+  }
+
+  if (clt1_z != NULL)
+  {
+    clt1_z->transfer = NULL; // prevent the transfer object of origin tracer being freed
+    ccl_cl_tracer_t_free(clt1_z);
+  }
+  if (clt2_z != NULL)
+  {
+    clt2_z->transfer = NULL;
+    ccl_cl_tracer_t_free(clt2_z);
+  }
 }
 
 #else
 
 //this is the public Angpow interface function to be used within CCL
-void ccl_angular_cls_angpow(ccl_cosmology *ccl_cosmo,CCL_ClWorkspace *w,
-				   CCL_ClTracer *clt1,CCL_ClTracer *clt2,
-				   double *cl_out,int * status)
+void ccl_angular_cls_angpow(ccl_cosmology *ccl_cosmo,
+				   ccl_cl_tracer_t *clt1, ccl_cl_tracer_t *clt2, ccl_f2d_t *psp,
+				   int nl_out, int *l_out, double *cl_out, int *status)
 {
   printf("ccl_angular_cls_angpow: HAVE_ANGPOW has not been defined then Angpow is not included in CCL\n");
 }

--- a/inc/Angpow/angpow_ccl_private.h
+++ b/inc/Angpow/angpow_ccl_private.h
@@ -1,8 +1,6 @@
 #ifndef ANGPOW_CCL_PRIVATE_SEEN
 #define ANGPOW_CCL_PRIVATE_SEEN
 
-
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -11,32 +9,31 @@ extern "C" {
 // these declarations are here to substitute the corresponding CCL declaration to compile agpow_ccl.cc file without reference to CCL  
 #ifdef INFILE_ANGPOWCCL_CC   
 //declaration of structures
-typedef struct s_splpar SplPar; // correspond to SplPar
+typedef struct s_f1d ccl_f1d_t; // correspond to ccl_f1d_t
+typedef struct s_f2d ccl_f2d_t; // correspond to ccl_f2d_t (type of psp)
 typedef struct s_cosmology ccl_cosmology; // correspond to ccl_cosmology
-typedef struct s_cltracer CCL_ClTracer; // correspond to CCL_ClTracer
-typedef struct s_clworkspace CCL_ClWorkspace; // correspond to CCL_ClWorksapce
+typedef struct s_cltracer ccl_cl_tracer_t; // correspond to ccl_cl_tracer_t
 #endif
 
-struct angpow_cltracer { int has_rsd; int has_magnification; double chimin; double chimax; double zmin; double zmax; SplPar * spl_bz; SplPar * spl_nz;};
-struct angpow_clworkspace { int lmax; int l_limber; int l_linstep; double l_logstep; int * l_arr;};
+struct tracer_range { double chimin; double chimax; double zmin; double zmax;};
 
 //declarations of functions
-typedef double (* Spline_eval)(double , SplPar *); // correspond to ccl_spline_eval
+typedef double (* F1d_eval)(ccl_f1d_t *, double);  // correspond to ccl_f1d_t_eval
+typedef double (* F2d_eval)(ccl_f2d_t *, double, double, void *, int *);  // correspond to ccl_f2d_t_eval
+typedef double (* Tracer_get_kernel)(ccl_cl_tracer_t *, double, int *);  //correspond to ccl_cl_tracer_t_get_kernel
+typedef double (* Tracer_get_transfer)(ccl_cl_tracer_t *, double, double, int *);  //correspond to ccl_cl_tracer_t_get_transfer
 typedef double (* Comoving_radial_distance)(ccl_cosmology *, double , int *); // correspond to ccl_comoving_radial_distance
 typedef double (* Scale_factor_of_chi)(ccl_cosmology *, double , int *); // correspond to ccl_scale_factor_of_chi
-typedef double (* Growth_rate)(ccl_cosmology *, double , int *); // correspond to ccl_growth_rate
-typedef double (* Nonlin_matter_power)(ccl_cosmology *, double , double , int *); // correspond to ccl_non_linear_matter_power
 
-void ccl_angular_cls_angpow_default(Spline_eval spl, Comoving_radial_distance chi,
-				    Scale_factor_of_chi a, Growth_rate f, Nonlin_matter_power P,
-				    ccl_cosmology *ccl_cosmo, CCL_ClWorkspace *w,
-				    CCL_ClTracer *clt1,CCL_ClTracer *clt2,
-				    struct angpow_cltracer *a_clt1, struct angpow_cltracer *a_clt2, struct angpow_clworkspace *a_w,	    
-				    char * message, double *cl_out,int * status);
+void ccl_angular_cls_angpow_default(F1d_eval f1d_eval, F2d_eval f2d_eval,
+					Comoving_radial_distance chi_of_a, Scale_factor_of_chi a_of_chi,
+					Tracer_get_kernel get_kernel, Tracer_get_transfer transfer,
+					ccl_f2d_t *psp, ccl_cosmology *ccl_cosmo, ccl_cl_tracer_t *clt1, ccl_cl_tracer_t *clt2,
+				    struct tracer_range *clt1_range, struct tracer_range *clt2_range, int *ell_values, int n_ells,
+				    char *message, double *cl_out, int *status);
 
 #ifdef __cplusplus
 }
 #endif
 
-  
 #endif// ANGPOW_CCL_PRIVATE_SEEN

--- a/src/angpow_ccl.cc
+++ b/src/angpow_ccl.cc
@@ -3,9 +3,9 @@
 #include <stdio.h>
 #include <string.h>
 #include <algorithm>
+#include <numeric>
 #include "gsl/gsl_errno.h"
 #include "gsl/gsl_integration.h"
-//#include "Angpow/angpow_ccl.h"
 #include "Angpow/angpow_tools.h"
 #include "Angpow/angpow_parameters.h"
 #include "Angpow/angpow_pk2cl.h"
@@ -21,30 +21,27 @@
 #define INFILE_ANGPOWCCL_CC 
 #include "Angpow/angpow_ccl_private.h"
 
-
 #define CCL_ERROR_ANGPOW 1042
 
 
 //! Here CCL is passed to Angpow base classes
 namespace Angpow {
-
-
-  //! Selection window W(z) with spline input from CCL 
-  class RadSplineSelect : public RadSelectBase {
+  //! Selection window W(z) with spline input from CCL
+  class RadSelectCCL : public RadSelectBase
+  {
   public:
-  RadSplineSelect(Spline_eval f, SplPar * spl,double x0,double xf): 
-    RadSelectBase(x0, xf), f_(f), spl_(spl) {}
-    
-    
+    RadSelectCCL(Tracer_get_kernel get_kernel, ccl_cl_tracer_t *clt, double x0, double xf) :
+      RadSelectBase(x0, xf), get_kernel_(get_kernel), clt_(clt) {}
+
     virtual r_8 operator()(r_8 z) const {
-      return f_(z,spl_);
+      int status = 0;
+      return get_kernel_(clt_, z, &status);
     }
-    
+
   private:
-    Spline_eval f_;
-    SplPar * spl_;
-  };//RadSplineSelect
-  
+    Tracer_get_kernel get_kernel_;
+    ccl_cl_tracer_t *clt_;
+  }; // RadSplineSelect
 
   //! This class import the cosmology from CCL to make the conversion z <-> r(z)
   //! and then to compute the cut-off in the integrals
@@ -62,7 +59,7 @@ namespace Angpow {
     //! r(z): radial comoving distance Mpc
     inline virtual double r(double z) const {
       int status=0;
-      return chi_(ccl_cosmo_,1./(1+z),&status);
+      return chi_(ccl_cosmo_, 1./(1.+z), &status);
     }
     //! z(r): the inverse of radial comoving distance (Mpc)
     inline virtual double z(double r) const {
@@ -80,55 +77,33 @@ namespace Angpow {
   //! Base class of half the integrand function
   //! Basically Angpow does three integrals of the form
   //!    C_ell = int dz1 int dz2 int dk f1(ell,k,z1)*f2(ell,k,z2)
-  //! This class set the f1 and f2 functions from CCL_ClTracer class
-  //! for galaxy counts :
-  //!    f(ell,k,z) = k*sqrt(P(k,z))*[ b(z)*j_ell(r(z)*k) + f(z)*j"_ell(r(z)*k) ]
+  //! This class set the f1 and f2 functions from ccl_cl_tracer_c class
   class IntegrandCCL : public IntegrandBase {
   public:
-  IntegrandCCL(Comoving_radial_distance chi, Growth_rate f, Nonlin_matter_power P, Spline_eval spl,
-	        angpow_cltracer* clt, ccl_cosmology* cosmo,int ell=0, r_8 z=0.):
-    chi_(chi), f_(f), P_(P), spl_(spl), clt_(clt), cosmo_(cosmo), ell_(ell), z_(z) {
-      Init(ell,z);
+    IntegrandCCL(Comoving_radial_distance chi, F2d_eval f2d_eval, Tracer_get_transfer get_transfer,
+                 ccl_f2d_t *psp, ccl_cl_tracer_t *clt, ccl_cosmology *cosmo, int ell = 0, r_8 z = 0.) :
+                 chi_(chi), f2d_eval_(f2d_eval), get_transfer_(get_transfer), psp_(psp), clt_(clt), cosmo_(cosmo), ell_(ell), z_(z)
+    {
+      Init(ell, z);
     }
     //! Initialize the function f(ell,k,z) at a given ell and z
     //! to be integrated over k
-    void Init(int ell, r_8 z){
-      int status=0;
-      ell_=ell; z_=z;
-      R_=chi_(cosmo_,1.0/(1+z),&status);
-      jlR_ = new JBess1(ell_,R_);
-      if(clt_->has_rsd) {
-	jlp1R_ = new JBess1(ell_+1,R_);
-	// WARNING: here we want to store dlnD/dln(+1z) = - dlnD/dlna
-	fz_= - f_(cosmo_,1.0/(1+z), &status);
-      }
-      bz_ = spl_(z,clt_->spl_bz);
+    void Init(int ell, r_8 z) {
+      int status = 0;
+      ell_ = ell;
+      z_ = z;
+      R_ = chi_(cosmo_, 1.0 / (1 + z), &status);
+      jlR_ = new JBess1(ell_, R_);
     }
     virtual ~IntegrandCCL() {}
     //! Return f(ell,k,z) for a given k
-    //! (ell and z must be initialized before) 
+    //! (ell and z must be initialized before)
     virtual r_8 operator()(r_8 k) const {
-      int status=0;
-      r_8 Pk=P_(cosmo_,k,1./(1+z_),&status);
-      r_8 x = k*R_;
+      int status = 0;
+      r_8 Pk = f2d_eval_(psp_, log(k), 1./(1+z_), cosmo_, &status);
       r_8 jlRk = (*jlR_)(k);
-      r_8 delta = bz_*jlRk; // density term with bias
-      if(clt_->has_rsd){ // RSD term
-	r_8 jlRksecond = 0.;
-	if(x<1e-40) { // compute second derivative j"_ell(r(z)*k)
-	  if(ell_==0) {
-	    jlRksecond = -1./3. + x*x/10.;
-	  } else if(ell_==2) {
-	    jlRksecond = 2./15. - 2*x*x/35.;
-	  } else {
-	    jlRksecond = 0.;
-	  }
-	} else {
-	  jlRksecond = 2.*(*jlp1R_)(k)/x + (ell_*(ell_-1.)/(x*x) - 1.)*jlRk;
-	}
-	delta += fz_*jlRksecond;
-      }
-      return(k*sqrt(fabs(Pk))*delta);
+      r_8 transfer = get_transfer_(clt_, log(k), 1./(1.+z_), &status); // transfer function defined in tracer object
+      return (k * sqrt(fabs(Pk)) * transfer * jlRk);
     }
     //! Clone function for OpenMP integration
     virtual IntegrandCCL* clone() const {
@@ -136,96 +111,115 @@ namespace Angpow {
     }
     virtual void ExplicitDestroy() {
       if(jlR_) delete jlR_;
-      if(jlp1R_) delete jlp1R_;
     }
   private:
     Comoving_radial_distance chi_; // function to get comoving radial distance from redshift
-    Growth_rate f_; // function to get growth rate from redshift
-    Nonlin_matter_power P_; // funciton to get matter power spectrum
-    Spline_eval spl_;
-    angpow_cltracer* clt_;  //no ownership
+    F2d_eval f2d_eval_;  // function to evaluate ccl power spectrum
+    Tracer_get_transfer get_transfer_;  // function to evaluate transfer function
+    ccl_f2d_t *psp_; // ccl power spectrum object
+    ccl_cl_tracer_t *clt_;  // no ownership
     ccl_cosmology* cosmo_;  //no ownership
     int ell_;  // multipole ell
     r_8 z_;   // redshift z
     r_8 R_;   // radial comoving distance r(z)
-    r_8 fz_;  // growth rate f(z)
-    r_8 bz_;  // bias b(z)
     JBess1* jlR_;  // j_ell(k*R)
-    JBess1* jlp1R_;   // j_(ell+1)(k*R)
     
     //Minimal copy to allow Main operator(int, r_8, r_8) to work
     //JEC 22/4/17 use cloning of PowerSpectrum
-    IntegrandCCL(const IntegrandCCL& copy) : clt_(copy.clt_), chi_(copy.chi_),f_(copy.f_),
-					     P_(copy.P_),spl_(copy.spl_),
-					     cosmo_(copy.cosmo_), ell_(0), z_(0), jlR_(0), jlp1R_(0){} 
+    IntegrandCCL(const IntegrandCCL& copy) : chi_(copy.chi_), f2d_eval_(copy.f2d_eval_), get_transfer_(copy.get_transfer_),
+					     psp_(copy.psp_), clt_(copy.clt_), cosmo_(copy.cosmo_), ell_(0), z_(0), jlR_(0){} 
 
   };//IntegrandCCL
 
+  //! This class represents the output Cls from Angpow
+  //! Allows passing the ell values to be computed explicitly
+  class CloutCCL : public Clbase
+  {
+  public:
+    CloutCCL(std::vector<int> ells) : Clbase(0), cl_map_updated_(false) {
+      ells_ = ells;
+      sort(ells_.begin(), ells_.end());
 
+      cls_.resize(ells_.size());
+      for (int i = 0; i < ells_.size(); i++) {
+          cls_[i].first = ells_[i];
+      }
+
+      Lmax_ = ells_.back();
+      ellsAll_.resize(Lmax_);
+      std::iota(std::begin(ellsAll_), std::end(ellsAll_), 0); // 0, 1,..., Lmax-1
+      maximal_ = (ells_ == ellsAll_);
+    }
+
+    Acl &operator[](int index_l) {
+      cl_map_updated_ = false;
+      return Clbase::operator[](index_l);
+    }
+
+    void Interpolate() {
+      Clbase::Interpolate();
+      updateClMap();
+    }
+
+    void updateClMap() {
+      for (auto &cl : cls_) {
+        cl_map_[cl.first] = cl.second;
+      }
+      cl_map_updated_ = true;
+    }
+
+    double getClOfEll(int ell) {
+      if (!cl_map_updated_) {
+        updateClMap();
+      }
+      return cl_map_.at(ell);
+    }
+
+  private:
+    std::map<int, double> cl_map_;
+    bool cl_map_updated_;
+  }; //CloutCCL
 }//end namespace
 
-
-
-void ccl_angular_cls_angpow_default(Spline_eval spl, Comoving_radial_distance chi,
-			    Scale_factor_of_chi a, Growth_rate f, Nonlin_matter_power P,
-			    ccl_cosmology *ccl_cosmo, CCL_ClWorkspace *w,
-			    CCL_ClTracer *clt1,CCL_ClTracer *clt2,
-			    struct angpow_cltracer *a_clt1, struct angpow_cltracer *a_clt2,
-			    struct angpow_clworkspace *a_w,	    
-			    char * message, double *cl_out,int * status)
+void ccl_angular_cls_angpow_default(F1d_eval f1d_eval, F2d_eval f2d_eval,
+                                    Comoving_radial_distance chi_of_a, Scale_factor_of_chi a_of_chi,
+                                    Tracer_get_kernel get_kernel, Tracer_get_transfer get_transfer,
+                                    ccl_f2d_t *psp, ccl_cosmology *ccl_cosmo, ccl_cl_tracer_t *clt1, ccl_cl_tracer_t *clt2,
+                                    struct tracer_range *clt1_range, struct tracer_range *clt2_range, int *ell_values, int n_ells,
+                                    char *message, double *cl_out, int *status)
 {
   // Initialize the Angpow parameters
-  int chebyshev_order_1=9; // polynoms of order 2^{N}
-  int chebyshev_order_2=9;
-  int nroots=200; 
-  int l_max_use=std::min(a_w->l_limber,a_w->lmax);
-  double cl_kmax= 3.14*l_max_use/std::min(a_clt1->chimin,a_clt2->chimin); 
-  int nsamp_z_1=(int)(std::max((double)15,0.124*cl_kmax*(a_clt1->chimin+a_clt1->chimax)-0.76*l_max_use));
-  int nsamp_z_2=(int)(std::max((double)15,0.124*cl_kmax*(a_clt2->chimin+a_clt2->chimax)-0.76*l_max_use));
-  //benchmark prints
-  /*
-  printf("lmax= %d l_limber= %d\n", l_max_use,a_w->l_limber);
-  printf("chebyshevorder1: %d chebyshevorder2: %d\n",chebyshev_order_1,chebyshev_order_2);
-  printf("radialorder1: %d radialorder2: %d\n", nsamp_z_1,nsamp_z_2);
-  printf("kmax= %.lg\n", cl_kmax);
-  printf("nroots= %d\n",nroots);
-  printf(" %.lg %.lg\n", (double)a_clt1->chimax,(double)a_clt1->chimin);//,a_w->dchi);
-  printf(" %.lg %.lg\n", (double)a_clt2->chimax,(double)a_clt2->chimin);//,a_w->dchi);
-  */
-  // Initialize the radial selection windows W(z)
-  Angpow::RadSplineSelect Z1win(spl,a_clt1->spl_nz,a_clt1->zmin,a_clt1->zmax);
-  Angpow::RadSplineSelect Z2win(spl,a_clt2->spl_nz,a_clt2->zmin,a_clt2->zmax);
- 
-  // The cosmological distance tool to make the conversion z <-> r(z)
-  Angpow::CosmoCoordCCL cosmo(chi,a,ccl_cosmo);
-  // Initilaie the two integrand functions f(ell,k,z)
-  Angpow::IntegrandCCL int1(chi,f,P,spl,a_clt1,ccl_cosmo);
-  Angpow::IntegrandCCL int2(chi,f,P,spl,a_clt2,ccl_cosmo);
+  int chebyshev_order_1 = 9; // polynoms of order 2^{N}
+  int chebyshev_order_2 = 9;
+  int nroots = 200;
 
   // Initialize the Cl with parameters to select the ell set which is interpolated after the processing
-  Angpow::Clbase clout(l_max_use+1,a_w->l_linstep,a_w->l_logstep);
-  // Check Angpow's ells match those of CCL (maybe we could to pass those ells explicitly to Angpow)
-  for(int index_l=0; index_l<clout.Size(); index_l++) {
-    if(clout[index_l].first!=a_w->l_arr[index_l]) {
-      *status=CCL_ERROR_ANGPOW;
-      strcpy(message,"ccl_cls.c: ccl_angular_cls_angpow_default(); "
-	     "ell-bins defined in angpow don't match those of CCL\n");
-      return;
-    }
-  }
+  std::vector<int> ells(ell_values, ell_values + n_ells);
+  Angpow::CloutCCL clout(ells);
+
+  int l_max_use = clout.InitialElls().back();
+  double cl_kmax = 3.14 * l_max_use / std::min(clt1_range->chimin, clt2_range->chimin);
+  int nsamp_z_1 = (int)(std::max((double)15, 0.124 * cl_kmax * (clt1_range->chimin + clt1_range->chimax) - 0.76 * l_max_use));
+  int nsamp_z_2 = (int)(std::max((double)15, 0.124 * cl_kmax * (clt2_range->chimin + clt2_range->chimax) - 0.76 * l_max_use));
+
+  // Initialize the radial selection windows W(z)
+  Angpow::RadSelectCCL Z1win(get_kernel, clt1, clt1_range->zmin, clt1_range->zmax);
+  Angpow::RadSelectCCL Z2win(get_kernel, clt2, clt2_range->zmin, clt2_range->zmax);
+  // The cosmological distance tool to make the conversion z <-> r(z)
+  Angpow::CosmoCoordCCL cosmo(chi_of_a, a_of_chi, ccl_cosmo);
+  // Initilaie the two integrand functions f(ell,k,z)
+  Angpow::IntegrandCCL int1(chi_of_a, f2d_eval, get_transfer, psp, clt1, ccl_cosmo);
+  Angpow::IntegrandCCL int2(chi_of_a, f2d_eval, get_transfer, psp, clt2, ccl_cosmo);
 
   // Main class to compute Cl with Angpow
-  Angpow::Pk2Cl pk2cl; //Default: the user parameters are used in the Constructor 
-  pk2cl.SetOrdFunc(chebyshev_order_1,chebyshev_order_2);
-  pk2cl.SetRadOrder(nsamp_z_1,nsamp_z_2);
+  Angpow::Pk2Cl pk2cl; // Default: the user parameters are used in the Constructor
+  pk2cl.SetOrdFunc(chebyshev_order_1, chebyshev_order_2);
+  pk2cl.SetRadOrder(nsamp_z_1, nsamp_z_2);
   pk2cl.SetKmax(cl_kmax);
-  pk2cl.SetNRootPerInt(nroots); 
-  pk2cl.Compute(int1,int2,cosmo,&Z1win,&Z2win,clout[clout.Size()-1].first+1,clout);
+  pk2cl.SetNRootPerInt(nroots);
+  pk2cl.Compute(int1, int2, cosmo, &Z1win, &Z2win, clout[clout.Size() - 1].first + 1, clout);
 
   // Pass the Clbase class values (ell and C_ell) to the output spline
-  for(int index_l=0; index_l<clout.Size(); index_l++)
-    cl_out[index_l]=clout[index_l].second;
+  for (int index_l = 0; index_l < n_ells; index_l++)
+    cl_out[index_l] = clout.getClOfEll(ell_values[index_l]);
 }
-
-
-  


### PR DESCRIPTION
Modificates Angpow4CCL to make it compatible with the latest version of CCL, which has undergone significant updates since the removal of Angpow4 in version 2.0.0. Corresponding modifications of CCL is in [this commit](https://github.com/mzLi01/CCL/commit/8c5ed7d15b958e51d613f2025adc9b1631a55eac#diff-169639e34f5d215d6576b55ff69bec05e0c8c034be4927dc2e8cba975908f524) of the repository CCL.